### PR TITLE
fixed the redirect bug

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,7 @@ class RegistrationsController < ApplicationController
   def create
     @user = User.new(params.require(:user).permit(:email, :password, :password_confirmation, :name))
     if @user.save
-      session[:user] = @user.id
+      session[:user_id] = @user.id
       redirect_to root_path
     else
       render :new


### PR DESCRIPTION
Fixed an issue when a new user registers, they get redirected to the sign in page when it should redirect them to the homepage. After looking in the router file to find the issue, the issue actually occurred inside the register controller. Inside of the session[] it requires a :user_id instead of a :user. This throws an error when it tries to get redirected to the root path because it checks to see if the session is valid before redirecting. Since the session variable contained an unknown parameter it redirected to the sign in page instead.

Reproducing the bug: change :user_id to :user.
