### PR TITLE
Greg redirect

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,7 @@ class RegistrationsController < ApplicationController
   def create
     @user = User.new(params.require(:user).permit(:email, :password, :password_confirmation, :name))
     if @user.save
-      session[:user] = @user.id
+      session[:user_id] = @user.id
       redirect_to root_path
     else
       render :new

--- a/spec/features/regis_spec.rb
+++ b/spec/features/regis_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require 'capybara/rails'
+
+feature 'Auth' do
+
+	scenario 'new registered user should become current user' do
+		 c = 'registrations'
+		 a = 'new'
+		visit (url_for :controller =>c, :action => a) 
+			fill_in 'Name', with: 'test'
+			fill_in "Email", with: "test@example.com"
+    		fill_in "Password", with: "password"
+    		fill_in "Confirm", with: "password"
+    		within(".registration-form") { click_on "Register" }
+    		expect(page).to have_content('You are logged in successfully')
+    end
+  end


### PR DESCRIPTION
Fixed the redirect bug for when a user signs up. The application verifies the current user based on the `user_id` variable, which is based on the id of the user in the database. The registration controller saves to `user`, which is the wrong variable, and thus doesn't redirect after registration, while still adding it into the database.

Added a test file to spec/features called `regis_spec.rb` to verify the successful redirect
