### PR TITLE
fix login after registering

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,7 @@ class RegistrationsController < ApplicationController
   def create
     @user = User.new(params.require(:user).permit(:email, :password, :password_confirmation, :name))
     if @user.save
-      session[:user] = @user.id
+      session[:user_id] = @user.id
       redirect_to root_path
     else
       render :new

--- a/spec/features/auth_spec.rb
+++ b/spec/features/auth_spec.rb
@@ -16,4 +16,19 @@ feature 'Auth' do
     expect(page).to have_content("user@example.com")
   end
 
+  scenario 'Users can login and out' do
+    create_user email: "user@example.com"
+
+    visit root_path
+    within(".auth") { click_on "Register" }
+    expect(page).to have_content("Register")
+
+    fill_in "Email", with: "user@example.com"
+    fill_in "Password", with: "password"
+    fill_in "Confirm", with: "password"
+
+    within(".registration-form") { click_on "Register" }
+    expect(current_path).to eql(registrations_path)
+  end
+
 end


### PR DESCRIPTION
The bug occurs when users register for a new account. Instead of logging the users in after registration, the user would be sent back to the login page. The bug occurred in the registrations_controller. The session key was not setup properly. I changed the session key from :user to :user_id to fix the bug on line 12 of the registrations_controller. I added a test to the Auth feature test make sure users were not redirected to the login page after registering.
