### PR TITLE
Registration redirect bug fixed

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,7 @@ class RegistrationsController < ApplicationController
   def create
     @user = User.new(params.require(:user).permit(:email, :password, :password_confirmation, :name))
     if @user.save
-      session[:user] = @user.id
+      session[:user_id] = @user.id
       redirect_to root_path
     else
       render :new


### PR DESCRIPTION
Fixed the bug where after a user registers on our site, it redirects them to the login page, forcing them to re enter their credentials. Now after registering for the site, the user is automatically taken to the home page and doesn't have to sign in again.
